### PR TITLE
added migrate with ensured deleted for test purposes

### DIFF
--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -136,12 +136,12 @@ app.UseSwaggerUI(c => { c.SwaggerEndpoint("/swagger/v1/swagger.json", "IGroceryS
 app.MapFallbackToFile("index.html");
 
 var databaseInitializer = app.Services.GetRequiredService<DbInitializer>();
-if (!builder.Environment.IsDevelopment() && !builder.Environment.IsTestEnvironment())
+if (builder.Environment.IsDevelopment() || builder.Environment.IsTestEnvironment())
 {
-    await databaseInitializer.MigrateAsync(moduleAssemblies);
+    await databaseInitializer.MigrateWithEnsuredDeletedAsync(moduleAssemblies);
 }
 else
 {
-    await databaseInitializer.MigrateWithEnsuredDeletedAsync(moduleAssemblies);
+    await databaseInitializer.MigrateAsync(moduleAssemblies);
 }
 app.Run();

--- a/src/API/Services/DbInitializer.cs
+++ b/src/API/Services/DbInitializer.cs
@@ -22,6 +22,27 @@ internal sealed class DbInitializer
             .Where(x => x is DbContext)
             .Cast<DbContext>();
         
+        // "If the database exists, then no effort is made to ensure it is compatible with the model for this context."
+        // https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.storage.relationaldatabasecreator.ensurecreatedasync?view=efcore-6.0
+        // I think in production it may be a problem
+        // Also, as far as I know, EnsureCreatedAsync() makes transaction in read-commited isolation level
+        // which still can make race hazard so maybe it's better to make change line to 
+        // contexts.ToList().ForEach(x => x.Database.EnsureCreatedAsync()); or something similar.
+        var migrations = contexts.Select(x => x.Database.EnsureCreatedAsync());
+        await Task.WhenAll(migrations);
+    }
+
+    public async Task MigrateWithEnsuredDeletedAsync(IEnumerable<Assembly> assemblies)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var services = scope.ServiceProvider;
+        var contexts = GetContexts(assemblies)
+            .Select(x => services.GetRequiredService(x))
+            .Where(x => x is DbContext)
+            .Cast<DbContext>();
+
+        await contexts.FirstOrDefault()!.Database.EnsureDeletedAsync();
+
         var migrations = contexts.Select(x => x.Database.EnsureCreatedAsync());
         await Task.WhenAll(migrations);
     }

--- a/src/Shared/Shared/Services/EnvironmentService.cs
+++ b/src/Shared/Shared/Services/EnvironmentService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace IGroceryStore.Shared.Services
+{
+    public static class EnvironmentService
+    {
+        public const string TestEnvironment = "Test";
+        public static bool IsTestEnvironment(this IHostEnvironment env) => 
+            env.EnvironmentName == TestEnvironment;
+        public static bool IsEnvironment(this IHostEnvironment env, string environment) =>
+            env.EnvironmentName == environment;
+
+    }
+}

--- a/tests/Users/Users.IntegrationTests/UserApiFactory.cs
+++ b/tests/Users/Users.IntegrationTests/UserApiFactory.cs
@@ -5,6 +5,7 @@ using DotNet.Testcontainers.Containers;
 using IGroceryStore.API;
 using IGroceryStore.Baskets.Core.Persistence;
 using IGroceryStore.Products.Core.Persistence.Contexts;
+using IGroceryStore.Shared.Services;
 using IGroceryStore.Users.Contracts.Events;
 using IGroceryStore.Users.Core.Persistence.Contexts;
 using MassTransit;
@@ -38,6 +39,8 @@ public class UserApiFactory : WebApplicationFactory<IApiMarker>, IAsyncLifetime
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureLogging(logging => { logging.ClearProviders(); });
+
+        builder.UseEnvironment(EnvironmentService.TestEnvironment);
 
         builder.ConfigureServices(services =>
         {

--- a/tests/Users/Users.IntegrationTests/Users/GetUserTests.cs
+++ b/tests/Users/Users.IntegrationTests/Users/GetUserTests.cs
@@ -31,19 +31,19 @@ public class GetUserTests : IClassFixture<UserApiFactory>
 
         // Act
         var response = await _client.GetAsync(responseWithUserLocation.Headers.Location);
-        
+
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var user = await response.Content.ReadFromJsonAsync<UserReadModel>();
         user.Should().NotBeNull();
-        
+
         response.RequestMessage!.RequestUri.Should().Be($"http://localhost/users/{user!.Id}");
         // TODO: Something is wrong with scrubber
-        response.RequestMessage.RequestUri = new Uri(response.RequestMessage.RequestUri!
+        response.RequestMessage!.RequestUri = new Uri(response.RequestMessage.RequestUri!
             .ToString()
             .Replace($"{user.Id}", "Guid_1"));
         await Verify(new { response, user });
-        
+
         //Cleanup
         await _apiFactory.RemoveUserById(user.Id);
     }


### PR DESCRIPTION
Instead of `builder.UseEnvironment(EnvironmentService.TestEnvironment);` may be defined different setting variable with `UseSetting()` which may reduce shotgun surgery effect. However, I've seen some desings with test env and in my opinion it is more flexible.

Also I wrote 
```
if (!builder.Environment.IsDevelopment() && !builder.Environment.IsTestEnvironment())
{
    await databaseInitializer.MigrateAsync(moduleAssemblies);
}
else
{
    await databaseInitializer.MigrateWithEnsuredDeletedAsync(moduleAssemblies);
}
```
which may be not desirable for development but it's up to you.

I do not exactly know why ensure deleted works, I only took this as a clue, and it looks like it works. 
>Ensures that the database for the context exists. If it exists, no action is taken.
