### PR TITLE
Remove redundant verified includes

### DIFF
--- a/tests/Users/Users.IntegrationTests/Users.IntegrationTests.csproj
+++ b/tests/Users/Users.IntegrationTests/Users.IntegrationTests.csproj
@@ -19,10 +19,4 @@
       <Folder Include="Tokens" />
     </ItemGroup>
 
-    <ItemGroup>
-      <None Update="Users\RegisterTests.Register_CreatesUser_WhenDataIsValid.verified.txt">
-        <DependentUpon>RegisterTests.cs</DependentUpon>
-      </None>
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
These occur due to a bug in VS where it incorrectly duplicates dynamic includes when you copy/rename a test file.